### PR TITLE
Fix compose url

### DIFF
--- a/front/app.js
+++ b/front/app.js
@@ -179,7 +179,7 @@ let hotkeys = [
     [['r a'], 'Reply all', () => {
         if (view.thread) go(view.last_email.links.replyall);
     }],
-    [['c'], 'Compose', () => go('/compose/')],
+    [['c'], 'Compose', () => go('/compose/new')],
     [['g i'], 'Go to Inbox', () => goToLabel('\\Inbox')],
     [['g d'], 'Go to Drafts', () => goToLabel('\\Drafts')],
     [['g s'], 'Go to Sent messages', () => goToLabel('\\Sent')],


### PR DESCRIPTION
Gui button redirects to ```/compose/new```, while shortcut ```c``` redirects to ```compose``` and gives:

    404 The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
