### PR TITLE
Change taboverride address, fix npm install failure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "normalize.css": "3.0.3",
     "partialify": "3.1.5",
     "postcss-cli": "2.3.2",
-    "taboverride": "github:wjbryant/taboverride",
+    "taboverride": "wjbryant/taboverride.git",
     "uglify-js": "2.5.0",
     "vue": "0.12.16",
     "whatwg-fetch": "0.10.1"


### PR DESCRIPTION
When using ```npm install``` I got the following errors:

    npm ERR! git clone git@github.com:github:wjbryant/taboverride fatal: remote error: 
    npm ERR! git clone git@github.com:github:wjbryant/taboverride    is not a valid repository name
    npm ERR! git clone git@github.com:github:wjbryant/taboverride   Email support@github.com for help
    npm ERR! 404 Not Found
    npm ERR! 404 
    npm ERR! 404 'taboverride' is not in the npm registry.
    npm ERR! 404 You should bug the author to publish it
    npm ERR! 404 
    npm ERR! 404 Note that you can also install from a
    npm ERR! 404 tarball, folder, or http url, or git url.

This behaviour is strange as it happened on my server (Debian Jessie, npm v1.4.21), but worked correctly on my laptop (Arch, npm v3.4.0). Perhaps it's due to the older version of npm.

My proposed fix (changing the line in ```package.json```) solved the problem was solved for Jessie and didn't break functionality for the newer version.

Can you confirm this change?