### PR TITLE
Remove key "main" config from for nginx

### DIFF
--- a/deploy/nginx-site-local.conf
+++ b/deploy/nginx-site-local.conf
@@ -2,7 +2,7 @@ server {
     listen 80;
     server_name 0.0.0.0;
 
-    access_log /var/log/access.log main;
+    access_log /var/log/access.log;
     error_log  /var/log/error.log;
 
     charset utf-8;


### PR DESCRIPTION
because it must be was set on http as log_format if not nginx not run because a error config.